### PR TITLE
Display comment popup when MandatoryCommentOnChangeResultState in db …

### DIFF
--- a/CxActionShared/Services/RESTApi/CxRESTApiPortalConfiguration.cs
+++ b/CxActionShared/Services/RESTApi/CxRESTApiPortalConfiguration.cs
@@ -46,6 +46,30 @@ namespace CxViewerAction.Services
             }
         }
 
+        public CxPortalConfiguration InitPortalConfigurationDetails()
+        {
+            try
+            {
+                LoginHelper.PortalConfiguration = new CxPortalConfiguration();
+                Uri uri = GetLoginUri();
+                HttpWebRequest webRequest = GetWebRequest(uri);
+                return GetWebResponse(webRequest);
+            }
+            catch (System.Net.WebException ex)
+            {
+                var response = (System.Net.HttpWebResponse)ex.Response;
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    LoginHelper.PortalConfiguration.WebServer = LoginHelper.ServerBaseUrl;
+                }
+                else
+                {
+                    Logger.Create().Error("CxRESTApiPortalConfiguration->InitPortalConfigurationDetails: " + ex.ToString());
+                }
+            }
+            return null;
+        }
         #endregion
 
         #region Private methods

--- a/CxActionShared/ValueObjects/WebPortal/Models/CxPortalConfiguration.cs
+++ b/CxActionShared/ValueObjects/WebPortal/Models/CxPortalConfiguration.cs
@@ -6,6 +6,8 @@
 
         public string WebServer { get; set; }
 
+        public bool MandatoryCommentOnChangeResultState { get; set; }
+
         #endregion
     }
 }

--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
@@ -31,7 +31,7 @@ namespace CxViewerAction.Views.DockedView
         private IPerspectiveView perspectiveView = null;
         private ReportQueryResult _selectedReportItem = null;
         private ReportResult _report = null;
-        private string _apiShortDescription= "sast/scans/{0}/results/{1}/shortDescription";
+        private string _apiShortDescription = "sast/scans/{0}/results/{1}/shortDescription";
         private string _apiAppSecCoachLessonsRequestData = "Queries/{0}/AppSecCoachLessonsRequestData";
         private string codeBashingTooltipMessage = "Learn more about {0} using Checkmarx’s eLearning platform";
         private const string descriptionHeader = "Codebashing";
@@ -52,7 +52,7 @@ namespace CxViewerAction.Views.DockedView
             {
                 Logger.Create().Error(ex.ToString());
             }
-                       
+
         }
 
         private void fillComboBoxes()
@@ -70,7 +70,7 @@ namespace CxViewerAction.Views.DockedView
                 cbAssign.Items.Add(new ComboBoxItem1("None", ""));
                 foreach (AssignUser user in ProjectAssignUsers)
                 {
-                    cbAssign.Items.Add(new ComboBoxItem1(user.UserName,user.UserName));
+                    cbAssign.Items.Add(new ComboBoxItem1(user.UserName, user.UserName));
                 }
             }
 
@@ -226,7 +226,7 @@ namespace CxViewerAction.Views.DockedView
             #endregion
         }
 
-        
+
         private TreeNodeData currentNodedata = null;
 
         private void SelectNode(TreeNodeData nodeData)
@@ -292,7 +292,7 @@ namespace CxViewerAction.Views.DockedView
             col.ReadOnly = true;
             dt.Columns.Add(col);
 
-            CxWSSingleResultData[] results  = PerspectiveHelper.GetScanResultsForQuery(nodeData.ScanId, nodeData.Id);          
+            CxWSSingleResultData[] results = PerspectiveHelper.GetScanResultsForQuery(nodeData.ScanId, nodeData.Id);
 
             int index = 1;
 
@@ -301,7 +301,7 @@ namespace CxViewerAction.Views.DockedView
                 string resultComment = reportQueryItemResult.Comment;
                 if (!string.IsNullOrEmpty(resultComment))
                 {
-                    string[] commentsArr = resultComment.Split(new char[]{Convert.ToChar(255)}, StringSplitOptions.RemoveEmptyEntries);
+                    string[] commentsArr = resultComment.Split(new char[] { Convert.ToChar(255) }, StringSplitOptions.RemoveEmptyEntries);
                     if (commentsArr.Length > 0)
                     {
                         resultComment = commentsArr[commentsArr.Length - 1];
@@ -317,7 +317,7 @@ namespace CxViewerAction.Views.DockedView
                     resultComment = string.Empty;
                 }
 
-                dt.Rows.Add(new object[] { 
+                dt.Rows.Add(new object[] {
                                            index,
                                            SavedResultsManager.ConvertResultStatusToString(reportQueryItemResult.ResultStatus),
                                            reportQueryItemResult.SourceFolder,
@@ -355,7 +355,7 @@ namespace CxViewerAction.Views.DockedView
                 break;
             }
 
-            if(currentNodedata != null)
+            if (currentNodedata != null)
             {
                 label2.Text = currentNodedata.Name;
                 toolTip1.SetToolTip(this.linkLabel1, string.Format(codeBashingTooltipMessage, currentNodedata.Name));
@@ -441,7 +441,7 @@ namespace CxViewerAction.Views.DockedView
 
         public void MarkRowAsSelected(long pathId)
         {
-            foreach(DataGridViewRow row in dgvProjects.Rows)
+            foreach (DataGridViewRow row in dgvProjects.Rows)
             {
                 if (Convert.ToInt64(row.Cells["PathId"].Value) == pathId)
                 {
@@ -455,16 +455,16 @@ namespace CxViewerAction.Views.DockedView
         {
             if (dgvProjects.SelectedRows.Count > 0)
             {
-				IsActive = true;
-				CxWSSingleResultData reportQueryItemPathResult = dgvProjects.SelectedRows[0].Cells["ResultEntity"].Value as CxWSSingleResultData;
-				int scanId = -1;
-				Int32.TryParse(dgvProjects.SelectedRows[0].Cells["ScanId"].Value.ToString(), out scanId);
+                IsActive = true;
+                CxWSSingleResultData reportQueryItemPathResult = dgvProjects.SelectedRows[0].Cells["ResultEntity"].Value as CxWSSingleResultData;
+                int scanId = -1;
+                Int32.TryParse(dgvProjects.SelectedRows[0].Cells["ScanId"].Value.ToString(), out scanId);
 
-				if (reportQueryItemPathResult == null)
-					return;
+                if (reportQueryItemPathResult == null)
+                    return;
 
-				this.SelectedRowChanged(this, new ResultData(reportQueryItemPathResult, scanId, this.SelectedNode));
-				UpdateGridShowPath();
+                this.SelectedRowChanged(this, new ResultData(reportQueryItemPathResult, scanId, this.SelectedNode));
+                UpdateGridShowPath();
             }
         }
 
@@ -532,7 +532,7 @@ namespace CxViewerAction.Views.DockedView
                 {
                     Logger.Create().Error(ex.ToString());
                 }
-                
+
             }
         }
 
@@ -588,7 +588,7 @@ namespace CxViewerAction.Views.DockedView
                     if (dgvProjects.Columns[columnIndex].HeaderText == Constants.COL_NAME_REMARK)
                     {
                         EditRemark(columnIndex, rowIndex);
-                        
+
                         return;
                     }
                     if (dgvProjects.SelectedRows.Count > 0)
@@ -619,7 +619,7 @@ namespace CxViewerAction.Views.DockedView
         {
             try
             {
-                if(this.SelectedNode !=null)
+                if (this.SelectedNode != null)
                 {
                     string responseText = string.Empty;
                     CxAppSecCodbashing codbashingDetails = new CxAppSecCodbashing();
@@ -641,7 +641,7 @@ namespace CxViewerAction.Views.DockedView
                         codbashingDetails = (CxAppSecCodbashing)javaScriptSerializer.Deserialize(responseText, typeof(CxAppSecCodbashing));
                     }
 
-                    if(codbashingDetails != null)
+                    if (codbashingDetails != null)
                     {
                         NavigateToCodebashing(codbashingDetails);
                     }
@@ -658,7 +658,7 @@ namespace CxViewerAction.Views.DockedView
             string urlToDescription = codbashingDetails.url + "?serviceProviderId=" + codbashingDetails.paramteres.serviceProviderId
             + "&utm_source=" + codbashingDetails.paramteres.utm_source
             + "&utm_campaign=" + codbashingDetails.paramteres.utm_campaign;
-           
+
             QueryDescriptionForm codebashingDesc = new QueryDescriptionForm(urlToDescription, OidcLoginData.GetOidcLoginDataInstance().AccessToken, descriptionHeader);
             codebashingDesc.Show();
 
@@ -669,9 +669,9 @@ namespace CxViewerAction.Views.DockedView
             string responseText = string.Empty;
             CxQueryShortDescription queryShortDescription = new CxQueryShortDescription();
 
-            CxRESTApiCommon rESTApiPortalConfiguration = new CxRESTApiCommon(string.Format(_apiShortDescription, scanId,pathId));
+            CxRESTApiCommon rESTApiPortalConfiguration = new CxRESTApiCommon(string.Format(_apiShortDescription, scanId, pathId));
             HttpWebResponse response = rESTApiPortalConfiguration.InitPortalBaseUrl();
-            
+
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 using (StreamReader reader = new StreamReader(response.GetResponseStream(), ASCIIEncoding.ASCII))
@@ -699,7 +699,7 @@ namespace CxViewerAction.Views.DockedView
             int currentColumnIndex = dgvProjects.CurrentCell.ColumnIndex;
 
             CxWSSingleResultData reportQueryItemPathResult = dgvProjects.Rows[rowIndex].Cells["ResultEntity"].Value as CxWSSingleResultData;
-             
+
             long pathId = reportQueryItemPathResult.PathId;
             long resultId = Convert.ToInt64(dgvProjects.Rows[rowIndex].Cells["ScanId"].Value);
             CxViewerAction.CxVSWebService.CxWSResultPath resultPath = PerspectiveHelper.GetPathCommentsHistory(resultId, pathId);
@@ -723,15 +723,15 @@ namespace CxViewerAction.Views.DockedView
                 }
             }
 
-            EditRemarkPopUp remarkPopUp = new EditRemarkPopUp("", sb.ToString());
+            EditRemarkPopUp remarkPopUp = new EditRemarkPopUp("", sb.ToString(),true);
 
             DialogResult result = remarkPopUp.ShowDialog();
-            
+
             if (result != DialogResult.OK)
                 return;
 
             string remark = remarkPopUp.Remark;
-            if(String.IsNullOrEmpty(remark))
+            if (String.IsNullOrEmpty(remark))
             {
                 return;
             }
@@ -751,7 +751,8 @@ namespace CxViewerAction.Views.DockedView
 
         public Dictionary<long, string> ResultStateList
         {
-            get{
+            get
+            {
                 if (stateList != null)
                 {
                     return stateList;
@@ -775,7 +776,7 @@ namespace CxViewerAction.Views.DockedView
                     {
                         Logger.Create().Error(ex.ToString());
                     }
-                                   
+
                 }
 
                 return stateList;
@@ -805,6 +806,36 @@ namespace CxViewerAction.Views.DockedView
 
         private void cbState_SelectionChangeCommitted(object sender, EventArgs e)
         {
+            if (!IsMandatoryCommentOnChangeResultState())
+            {
+                updateResultStateDetails(sender,"");
+            }
+            else
+            {
+                EditRemarkPopUp remarkPopUp = new EditRemarkPopUp("", "",false);
+
+                DialogResult result = remarkPopUp.ShowDialog();
+
+                if (result != DialogResult.OK)
+                    return;
+
+                string remark = remarkPopUp.Remark;
+                if (String.IsNullOrEmpty(remark))
+                {
+                    return;
+                }
+                else
+                {
+                    updateResultStateDetails(sender, remark);
+                }
+            }
+        }
+
+
+        private CheckBox checkboxHeader = new CheckBox();
+
+        private void updateResultStateDetails(object sender,string remark)
+        {
             bool needRefresh = false;
             try
             {
@@ -823,24 +854,24 @@ namespace CxViewerAction.Views.DockedView
                         {
                             data = item.Id.ToString(),
                             PathId = pathId,
-                            Remarks = string.Empty,
+                            Remarks = remark,
                             ResultLabelType = (int)CxViewerAction.Helpers.ResultLabelTypeEnum.State,
                             scanId = resultId
                         });
-                      
+
                     }
                 }
 
-                if (list.Count >0)
+                if (list.Count > 0)
                 {
-                    needRefresh = PerspectiveHelper.UpdateResultState(list.ToArray()); 
+                    needRefresh = PerspectiveHelper.UpdateResultState(list.ToArray());
                 }
 
                 if (needRefresh)
                 {
                     this.Refresh(this, currentNodedata);
                 }
-                
+
 
             }
             catch (Exception ex)
@@ -854,7 +885,11 @@ namespace CxViewerAction.Views.DockedView
             }
         }
 
-        private CheckBox checkboxHeader = new CheckBox();
+        private bool IsMandatoryCommentOnChangeResultState()
+        {
+            CxRESTApiPortalConfiguration rESTApiPortalConfiguration = new CxRESTApiPortalConfiguration();
+            return rESTApiPortalConfiguration.InitPortalConfigurationDetails().MandatoryCommentOnChangeResultState;
+        }
 
         private void show_chkBox()
         {
@@ -865,7 +900,7 @@ namespace CxViewerAction.Views.DockedView
             checkboxHeader.Name = "checkboxHeader";
             checkboxHeader.Size = new Size(18, 18);
             checkboxHeader.Location = rect.Location;
-            checkboxHeader.CheckedChanged -= new EventHandler(checkboxHeader_CheckedChanged);  
+            checkboxHeader.CheckedChanged -= new EventHandler(checkboxHeader_CheckedChanged);
             checkboxHeader.CheckedChanged += new EventHandler(checkboxHeader_CheckedChanged);
             dgvProjects.Controls.Add(checkboxHeader);
         }
@@ -874,7 +909,7 @@ namespace CxViewerAction.Views.DockedView
         {
             foreach (DataGridViewRow row in dgvProjects.Rows)
             {
-               row.Cells["checkBoxesColumn"].Value = checkboxHeader.Checked;
+                row.Cells["checkBoxesColumn"].Value = checkboxHeader.Checked;
             }
             dgvProjects.EndEdit();
         }
@@ -915,13 +950,13 @@ namespace CxViewerAction.Views.DockedView
                 {
                     this.Refresh(this, currentNodedata);
                 }
-               
+
             }
             catch (Exception ex)
             {
 
                 Logger.Create().Error(ex.ToString());
-               
+
             }
             finally
             {

--- a/CxActionShared/Views/EditRemarkPopUp.cs
+++ b/CxActionShared/Views/EditRemarkPopUp.cs
@@ -12,11 +12,17 @@ namespace CxViewerAction.Views
             get { return remark; }
         }
 
-        public EditRemarkPopUp(string currentRemark, string historyComments)
+        public EditRemarkPopUp(string currentRemark, string historyComments, bool isCommentHistoryVisible)
         {
             InitializeComponent();
             textBox.Text = currentRemark;
             txtCommentHistory.Text = historyComments;
+            if(!isCommentHistoryVisible)
+            {
+                label2.Visible = false;
+                txtCommentHistory.Visible = false;
+                this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 7F);
+            }
         }
 
 

--- a/CxViewer2022/source.extension.vsixmanifest
+++ b/CxViewer2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ade162dc-e470-4fc9-9868-2a878fb23422" Version="9.00.19" Language="en-US" Publisher="Checkmarx" />
+        <Identity Id="ade162dc-e470-4fc9-9868-2a878fb23422" Version="9.00.20" Language="en-US" Publisher="Checkmarx" />
         <DisplayName>CxViewer</DisplayName>
         <Description xml:space="preserve">Checkmarx Visual Studio Plugin</Description>
         <MoreInfo>https://checkmarx.atlassian.net/wiki/spaces/SD/pages/1339392185/Visual+Studio+Plugin</MoreInfo>

--- a/CxViewerVSIX/source.extension.vsixmanifest
+++ b/CxViewerVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="37506746-5265-481e-ac06-32f67910eedd" Publisher="Checkmarx" Version="9.00.19" Language="en-US" />
+        <Identity Id="37506746-5265-481e-ac06-32f67910eedd" Publisher="Checkmarx" Version="9.00.20" Language="en-US" />
         <DisplayName>CxViewer</DisplayName>
         <Description xml:space="preserve" >Checkmarx Visual Studio Plugin</Description>
         <MoreInfo>https://checkmarx.atlassian.net/wiki/spaces/SD/pages/1339392185/Visual+Studio+Plugin</MoreInfo>


### PR DESCRIPTION
**Changes** 
If **MandatoryCommentOnChangeResultState=true** in **cxcomponentConfiguration** table then previously comments popup is not displaying while **changing result state** . Now following same functionality as per SAST application.


**Test Case 1**
- Open CxViewer Result tree 
- Edit/Add comment
- Check in CxViewer Result tree  -> comments updated or not
- Click on Edit/Add comment and check comment hostory


**Test Case 2**
- Open DB and execute below command 
update CxComponentConfiguration set Value ='false' where [Key] like 'MandatoryCommentOnChangeResultState'
- MandatoryCommentOnChangeResultState==false then changing result state comment is not mandatory
- Select n number of results(checkbox checked for n no. of results)
- Update Result state to urgent (Or any)
- It will not open comments popup
- Automatically updates its status
- Check in CxViewer Result tree  -> comments updated or not


**Test Case 3**
- Open DB and execute below command 
update CxComponentConfiguration set Value ='true' where [Key] like 'MandatoryCommentOnChangeResultState'
- MandatoryCommentOnChangeResultState==true then changing result state comment is mandatory
- Select n number of results(checkbox checked for n no. of results)
- Update Result state to urgent(Or any)
- It will open comments popup
- Automatically updates its status
- Check in CxViewer Result tree  -> comments updated or not
