### PR TITLE
PLUG-1443

### DIFF
--- a/Common/Code/Constants.cs
+++ b/Common/Code/Constants.cs
@@ -61,7 +61,7 @@
 		public const string TOKEN_ENDPOINT = SAST_PREFIX + "/identity/connect/token";
 		public const string SAVE_SAST_SCAN = "save-sast-scan";
 		public const string MANAGE_RESULTS_COMMENT = "manage-result-comment";
-		public const string MANAGE_RESULTS_EXPLOITABILITY = "manage-result-exploitability";
+		public const string MANAGE_RESULTS_EXPLOITABILITY = "set-result-state-notexploitable";
 
 	}
 }


### PR DESCRIPTION
**Changes**
Replaced permission “Manage Result Exploitability” validation as a  “set-result-state-notexploitable”

**Test Cases**

Test Case 1
- Go to SAST -> Access Control -> Create new Role Test without set-result-state-notexploitable permissions
- Create new User with Role Test 
- Login with SAST using VS Plugin with new user-> Bind any project -> Click on any vulnaribility
- In CxViewer Result -> Open Set Result State dropdown 
Expected - Not Exploitable Result State should not be available in dropdown


Test Case 2
- Go to SAST -> Access Control -> CHeck the User Role Example- Admin
- Click on Roles -> Admin -> Edit
- Update set-result-state-notexploitable as true
- Login with SAST using VS Plugin -> Bind any project -> Click on any vulnaribility
- In CxViewer Result -> Open Set Result State dropdown 
Expected - Not Exploitable Result State should be available in dropdown

Test Case 3 
- Go to SAST -> Access Control -> CHeck the User Role Example- Admin
- Click on Roles -> Admin -> Edit
- Update set-result-state-notexploitable as true
- Login with SAST using VS Plugin -> Bind any project -> Click on any vulnaribility
- In CxViewer Result -> Select any vulnaribility ->  Update Set Result State as Not exploitable 
Expected - vulnaribility status updates as Not Exploitable 