### PR TITLE
changes related to short description

### DIFF
--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.Designer.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.Designer.cs
@@ -269,7 +269,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(12, 38);
-            this.label1.MaximumSize = new System.Drawing.Size(1600, 90);
+            this.label1.MaximumSize = new System.Drawing.Size(1600, 150);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(0, 20);
             this.label1.TabIndex = 0;

--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
@@ -674,7 +674,7 @@ namespace CxViewerAction.Views.DockedView
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                using (StreamReader reader = new StreamReader(response.GetResponseStream(), Encoding.UTF8))
                 {
                     responseText = reader.ReadToEnd();
                 }

--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
@@ -674,7 +674,7 @@ namespace CxViewerAction.Views.DockedView
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                using (StreamReader reader = new StreamReader(response.GetResponseStream(), ASCIIEncoding.ASCII))
+                using (StreamReader reader = new StreamReader(response.GetResponseStream()))
                 {
                     responseText = reader.ReadToEnd();
                 }
@@ -685,7 +685,7 @@ namespace CxViewerAction.Views.DockedView
                 JavaScriptSerializer javaScriptSerializer = new JavaScriptSerializer();
                 queryShortDescription = (CxQueryShortDescription)javaScriptSerializer.Deserialize(responseText, typeof(CxQueryShortDescription));
             }
-            this.label1.Text = queryShortDescription.shortDescription.Replace("??", " ");
+            this.label1.Text = queryShortDescription.shortDescription;
         }
 
         private void EditRemark(int columnIndex, int rowIndex)


### PR DESCRIPTION
**Changes**

Clicking the vulnerability "Reflected XSS All Clients" is incorrect short description appears.

**Test Cases**

- Open SAST -> Access Control -> Change Users Locale as Chinese
- Log in with the VS plugin  -> Bind Project
- Clicking the vulnerability "Reflected XSS All Clients" is incorrect short description appears.

Test short description with all languages


