### PR TITLE
resolved short description with locale lenguage

### DIFF
--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.Designer.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.Designer.cs
@@ -269,7 +269,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(12, 38);
-            this.label1.MaximumSize = new System.Drawing.Size(1600, 90);
+            this.label1.MaximumSize = new System.Drawing.Size(1600, 150);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(0, 20);
             this.label1.TabIndex = 0;

--- a/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
+++ b/CxActionShared/Views/DockedView/PerspectiveResultCtrl.cs
@@ -667,14 +667,13 @@ namespace CxViewerAction.Views.DockedView
         private void GetShortDescription(long scanId, long pathId)
         {
             string responseText = string.Empty;
-            CxQueryShortDescription queryShortDescription = new CxQueryShortDescription();
 
             CxRESTApiCommon rESTApiPortalConfiguration = new CxRESTApiCommon(string.Format(_apiShortDescription, scanId, pathId));
             HttpWebResponse response = rESTApiPortalConfiguration.InitPortalBaseUrl();
 
-            if (response.StatusCode == HttpStatusCode.OK)
+            if (response != null && response.StatusCode == HttpStatusCode.OK)
             {
-                using (StreamReader reader = new StreamReader(response.GetResponseStream(), ASCIIEncoding.ASCII))
+                using (StreamReader reader = new StreamReader(response.GetResponseStream(), Encoding.UTF8))
                 {
                     responseText = reader.ReadToEnd();
                 }
@@ -682,10 +681,17 @@ namespace CxViewerAction.Views.DockedView
 
             if (!string.IsNullOrEmpty(responseText))
             {
+                CxQueryShortDescription queryShortDescription = new CxQueryShortDescription();
                 JavaScriptSerializer javaScriptSerializer = new JavaScriptSerializer();
                 queryShortDescription = (CxQueryShortDescription)javaScriptSerializer.Deserialize(responseText, typeof(CxQueryShortDescription));
+                this.label1.Text = queryShortDescription.shortDescription;
+                this.label1.ForeColor = Color.Black;
             }
-            this.label1.Text = queryShortDescription.shortDescription.Replace("??", " ");
+            else
+            {
+                this.label1.Text = "The query description for vulnerability result is not available.\r\n";
+                this.label1.ForeColor = Color.Red;
+            }
         }
 
         private void EditRemark(int columnIndex, int rowIndex)


### PR DESCRIPTION
**Changes**
Some short description in a different language is not available. I display a Message to the user if a short description is unavailable.

**Tests**
- Open SAST -> Access Control -> Change Users Locale as Chinese
- Log in with the VS plugin -> Bind Project
- Clicking the vulnerability "Reflected XSS All Clients" throws an error.
Expected - If a short description is not available then display the below message 
**The query description for vulnerability result is not available**

