### PR TITLE
Plug 1134 - [Visual Studio] SSL_Verification_Bypass vulnarability fix

### DIFF
--- a/CxActionShared/Entities/LoginData.cs
+++ b/CxActionShared/Entities/LoginData.cs
@@ -64,6 +64,7 @@ namespace CxViewerAction.Entities
         private bool _manageResultsComment;
         private bool _manageResultsExploitability;
         private int _bindProjectCount = -1;
+        private bool _enableTLSOrSSLServerCertificateValidation = true;
 
         #endregion
 
@@ -277,6 +278,9 @@ namespace CxViewerAction.Entities
         public bool ManageResultsExploitability { get => _manageResultsExploitability; set => _manageResultsExploitability = value; }
 
         public int BindProjectCount { get { return _bindProjectCount; } set { _bindProjectCount = value; } }
+
+        public bool EnableTLSOrSSLServerCertificateValidation { get => _enableTLSOrSSLServerCertificateValidation; set => _enableTLSOrSSLServerCertificateValidation = value; }
+
         #endregion [ Properties ]
 
         #region [ Public Methods ]

--- a/CxActionShared/Helpers/HttpHelper.cs
+++ b/CxActionShared/Helpers/HttpHelper.cs
@@ -24,7 +24,8 @@ namespace CxViewerAction.Helpers
             try
             {
                 HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(url);
-                ServicePointManager.ServerCertificateValidationCallback += delegate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+                //This class is not in use. To avoid SSL_Verification_ByPass vulnarability by default SSL certificate validation enabled
+                ServicePointManager.ServerCertificateValidationCallback += delegate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return false; };
                 response = (HttpWebResponse)request.GetResponse();
 
                 using (StreamReader responseStream = new StreamReader(response.GetResponseStream()))

--- a/CxActionShared/Services/CxWebServiceClient.cs
+++ b/CxActionShared/Services/CxWebServiceClient.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Net.Security;
 using CxViewerAction.CxVSWebService;
 using CxViewerAction.Entities.WebServiceEntity;
+using Common;
 
 namespace CxViewerAction.Services
 {
@@ -61,7 +62,21 @@ namespace CxViewerAction.Services
         /// <param name="server">server url</param>
         public CxWebServiceClient(LoginData pLogin)
         {
-            ServicePointManager.ServerCertificateValidationCallback += delegate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager. ServerCertificateValidationCallback += delegate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) 
+            {
+                // No SSL policy errors, certificate is considered valid Or Certificate validation is disabled
+                if (!pLogin.EnableTLSOrSSLServerCertificateValidation || sslPolicyErrors == SslPolicyErrors.None)
+                    return true;
+                else
+                {
+                    // Log or handle SSL policy errors
+                    Logger.Create().Error("Certificate error: " + sslPolicyErrors.ToString());
+
+                    // Example: Check if the certificate is issued by a specific CA or meets specific criteria
+                    // Return false to reject the certificate
+                    return false;
+                }
+            };
 
             CxViewerAction.Services.CxWSResolverWrapper resolver = new CxViewerAction.Services.CxWSResolverWrapper { Url = pLogin.Server };
             resolver.DisableConnectionOptimizations = pLogin.DisableConnectionOptimizations;


### PR DESCRIPTION
**Changes** 
Resolved SSL_Verification_ByPass vulnarability

**Tests**
**Test Case 1** 
- Run a scan of the Visual Studio repo and check the SSL_Verification_Bypass vulnerability 
https://github.com/checkmarx-ltd/VisualStudio

**Test Case 2**
- By default, the value of EnableTLSOrSSLServerCertificateValidation is true in the conf file
- If EnableTLSOrSSLServerCertificateValidation == false then SSL Server Certificate Validation will be disabled
- else it will validate certificate details
- if certificate validation fails then displays error message and generates log

**Test Case 2**
Test this scenario with VS2019 and VS2022
