### PR TITLE
Support PMA (Pixel-based Multi-Anchor) for Visual Studio plugin

### DIFF
--- a/CxViewerShared/ToolWindows/GraphToolWindow.cs
+++ b/CxViewerShared/ToolWindows/GraphToolWindow.cs
@@ -13,6 +13,7 @@ namespace CxViewerVSIX.ToolWindows
     using System.Runtime.InteropServices;
     using System.Windows.Forms;
     using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Utilities;
 
     /// <summary>
     /// This class implements the tool window exposed by this package and hosts a user control.
@@ -41,14 +42,8 @@ namespace CxViewerVSIX.ToolWindows
 
         }
 
-        private PerspectiveGraphCtrl ctrl = new PerspectiveGraphCtrl(); 
-        public override IWin32Window Window
-        {
-            get
-            {
-                return ctrl;
-            }
-        }
+        private PerspectiveGraphCtrl ctrl;
+        override public IWin32Window Window { get { using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)) { if (ctrl == null) ctrl = new PerspectiveGraphCtrl(); return ctrl; } } }
 
         private static int id = 0;
         public static int ID

--- a/CxViewerShared/ToolWindows/PathToolWindow.cs
+++ b/CxViewerShared/ToolWindows/PathToolWindow.cs
@@ -13,6 +13,7 @@ namespace CxViewerVSIX.ToolWindows
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.Shell;
     using System.Windows.Forms;
+    using Microsoft.VisualStudio.Utilities;
 
     /// <summary>
     /// This class implements the tool window exposed by this package and hosts a user control.
@@ -41,14 +42,8 @@ namespace CxViewerVSIX.ToolWindows
 
         }
 
-        private PerspectivePathCtrl ctrl = new PerspectivePathCtrl();
-        public override IWin32Window Window
-        {
-            get
-            {
-                return ctrl;
-            }
-        }
+        private PerspectivePathCtrl ctrl;
+        override public IWin32Window Window { get { using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)) { if (ctrl == null) ctrl = new PerspectivePathCtrl(); return ctrl; } } }
 
         private static int id = 1;
         public static int ID

--- a/CxViewerShared/ToolWindows/ReportToolWindow.cs
+++ b/CxViewerShared/ToolWindows/ReportToolWindow.cs
@@ -13,6 +13,7 @@ namespace CxViewerVSIX.ToolWindows
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.Shell;
     using System.Windows.Forms;
+    using Microsoft.VisualStudio.Utilities;
 
     /// <summary>
     /// This class implements the tool window exposed by this package and hosts a user control.
@@ -40,14 +41,8 @@ namespace CxViewerVSIX.ToolWindows
             // the object returned by the Content property.
         }
 
-        private PerspectiveCtrl ctrl = new PerspectiveCtrl();
-        public override IWin32Window Window
-        {
-            get
-            {
-                return ctrl;
-            }
-        }
+        private PerspectiveCtrl ctrl;
+        override public IWin32Window Window { get { using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)) { if (ctrl == null) ctrl = new PerspectiveCtrl(); return ctrl; } } }
 
         private static int id = 2;
         public static int ID

--- a/CxViewerShared/ToolWindows/ResultsToolWindow.cs
+++ b/CxViewerShared/ToolWindows/ResultsToolWindow.cs
@@ -14,6 +14,7 @@ namespace CxViewerVSIX.ToolWindows
     using System.Windows.Forms;
     using Microsoft.VisualStudio.Shell;
     using EnvDTE;
+    using Microsoft.VisualStudio.Utilities;
 
     /// <summary>
     /// This class implements the tool window exposed by this package and hosts a user control.
@@ -42,14 +43,8 @@ namespace CxViewerVSIX.ToolWindows
             // the object returned by the Content property.
         }
 
-        private PerspectiveResultCtrl ctrl = new PerspectiveResultCtrl();
-        public override IWin32Window Window
-        {
-            get
-            {
-                return ctrl;
-            }
-        }
+        private PerspectiveResultCtrl ctrl;
+        override public IWin32Window Window { get { using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)) { if (ctrl == null) ctrl = new PerspectiveResultCtrl(); return ctrl; } } }
 
         private static int id = 3;
         public static int ID

--- a/CxViewerShared/ToolWindows/ScanProcessToolWindow.cs
+++ b/CxViewerShared/ToolWindows/ScanProcessToolWindow.cs
@@ -13,6 +13,7 @@ namespace CxViewerVSIX.ToolWindows
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.Shell;
     using System.Windows.Forms;
+    using Microsoft.VisualStudio.Utilities;
 
     /// <summary>
     /// This class implements the tool window exposed by this package and hosts a user control.
@@ -43,14 +44,9 @@ namespace CxViewerVSIX.ToolWindows
         }
 
 
-        private ScanProcessCtrl ctrl = new ScanProcessCtrl();
-        public override IWin32Window Window
-        {
-            get
-            {
-                return ctrl;
-            }
-        }
+        private ScanProcessCtrl ctrl;
+        override public IWin32Window Window { get { using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)) { if (ctrl == null) ctrl = new ScanProcessCtrl(); return ctrl; } } }
+
 
         private static int id = 4;
         public static int ID


### PR DESCRIPTION
Note - 
- Test below scenarios on VS 2019 and VS 2022 
- Test with checked and unchecked of 
   -  Optimize rendering for screens with different pixel densities

**Test  cases** 

- Go to Tools -> Options -> CxViewer -> Authentication -> Login with SAST Server
- Logout SAST Server
- Bind Project
- UnBind Project
- Cancel Bind Project
- Click on Bind Project -> Search Project name 
- Click on Bind Project -> Search Project name  -> Cancel Search project
- Open Documents\Visual Studio (2022\2019)\Settings\CxVSPlugin.conf file -> update BindProjectCount =2 -> again unbind and bind project -> only 2 projects will display to user and user can search project as well
- Run Full Scan Project
- Run Incremental project
- Retrieve Reuslts
- CxViewer scan progress -> click on vulnurablity high/low /medium
- Click on Expand All, Collapse All
- Click on Show description (After clicks opens in IE -> already new ticket added in JIRA)
- Open CxViewer Result -> Change Result state and verify
- Open CxViewer Result -> Change Result severity and verify
- Open CxViewer Result -> Change Assign to user and verify
- Open CxViewer Result -> click on any result it redirects to code
- Open CxViewer Result -> Add comments and verify comment
- Open CxViewer Graph -> click on block it redirects to code(BFL)
- Open CxViewer Path -> click on block it redirects to code(BFL)
- Close VS -> open again -> Project Unbound done